### PR TITLE
update node js version to 10 to fix letsencrypt ssl error

### DIFF
--- a/extensions/sonarcloud/tasks/buildbreaker/package.json
+++ b/extensions/sonarcloud/tasks/buildbreaker/package.json
@@ -10,8 +10,11 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "fs-extra": "5.0.0",
+    "fs-extra": "10.0.0",
     "request": "^2.87.0",
-    "azure-pipelines-task-lib": "2.8.0"
+    "azure-pipelines-task-lib": "^3.1.9"
+  },
+  "engines": {
+    "node": ">=10"
   }
 }

--- a/extensions/sonarqube/tasks/buildbreaker/package.json
+++ b/extensions/sonarqube/tasks/buildbreaker/package.json
@@ -10,8 +10,11 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "fs-extra": "5.0.0",
+    "fs-extra": "10.0.0",
     "request": "^2.87.0",
-    "azure-pipelines-task-lib": "2.8.0"
+    "azure-pipelines-task-lib": "^3.1.9"
+  },
+  "engines": {
+    "node": ">=10"
   }
 }


### PR DESCRIPTION
Extension is kappot doordat nodejs 6 gebruikt wordt. Dit zorgt dat ssl certificate van letsencrypt niet werkt. Door upgrade van azure-pipeline-task-lib en node versie is dit opgelost. @simondel  graag zo snel mogelijk aanpassen. Als je  vragen hebt kan je me bellen. 