### PR TITLE
Use buildId as part of taskReportGlob path when using sonarcloud in a…

### DIFF
--- a/extensions/sonarcloud/tasks/buildbreaker/common/sonarsource/sonarqube/TaskReport.ts
+++ b/extensions/sonarcloud/tasks/buildbreaker/common/sonarsource/sonarqube/TaskReport.ts
@@ -56,7 +56,7 @@ export default class TaskReport {
     } else {
       taskReportGlob = path.join(
         SONAR_TEMP_DIRECTORY_NAME,
-        tl.getVariable('Build.BuildNumber'),
+        tl.getVariable('Build.BuildId'),
         '**',
         REPORT_TASK_NAME
       );


### PR DESCRIPTION
…zure devops

The extension did not find any files and testing in azure devops, using sonarcloud.io shows me that: SQ i looking for files in: sonar/sonar_break_20240625.1/**/report-task.txt - found 0 file(s) Printing the Agent.TempDirectory i can see that the file is actually located in: sonar/18704/87264074-1364-6a3c-f93c-ce69286baa1d/report-task.txt

The Path part: sonar_break_20240625.1 is from Build.BuildNumber which is actually directly related to the custom name of the build (can be controlled by user) however the report in placed in a folder path using Build.BuildId (18704)

This is why the file cannot be found and the breaker cannot break the build if a gate is failing